### PR TITLE
Return Error with response data on failure.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,11 +83,26 @@ function requestPromise (url, agent) {
             if (error) {
                 return reject(error);
             }
+
+            function decorateError(error) {
+                if (!error) {
+                    throw new Error('error is required.');
+                }
+
+                error.url = url;
+                error.http_status = response.statusCode;
+                error.ratelimit_limit = response.headers['x-ratelimit-limit'];
+                error.ratelimit_remaining = response.headers['x-ratelimit-remaining'];
+                error.ratelimit_reset = parseInt(response.headers['x-ratelimit-reset'], 10);
+
+                return error;
+            }
+
             if (response.statusCode >= 500) {
-                return reject('Server error on url ' + url);
+                return reject(decorateError(new Error('Server error on url ' + url)));
             }
             if (response.statusCode >= 400) {
-                return reject('Client error on url ' + url);
+                return reject(decorateError(new Error('Client error on url ' + url)));
             }
             return resolve(body);
         });


### PR DESCRIPTION
We're seeing some failures on Travis and it's difficult to see what's going on.  This just annotates an `Error` object with some information from the response.  End goal is to be able to do something like:

![screen shot 2015-01-06 at 2 29 19 pm](https://cloud.githubusercontent.com/assets/214142/5635737/98dff71c-95b1-11e4-9e84-a153f4374d34.png)
